### PR TITLE
Allow the vault client to set the default config

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 		fatalf("could not read params file: %v\n", err)
 	}
 
-	client, err := vault.NewClient(vault.DefaultConfig())
+	client, err := vault.NewClient(nil)
 	if err != nil {
 		fatalf("could not connect to Vault: %v\n", err)
 	}


### PR DESCRIPTION
Using nil as the parameter for the API client will result in a default configuration that also loads all the environment variables meant for the HTTP client